### PR TITLE
Fix: Logo, Error Toast

### DIFF
--- a/src/wwwfiles/components/Logo/TeamLogo.tsx
+++ b/src/wwwfiles/components/Logo/TeamLogo.tsx
@@ -6,11 +6,11 @@ type TeamLogoProps = {
 
 export const TeamLogo = ({ src }: TeamLogoProps) => {
   return (
-    <div className="tw-h-full tw-w-fit tw-min-w-fit">
+    <div className="tw-h-full">
       {src ? (
         <img
           src={src}
-          className="tw-h-full tw-w-fit tw-min-w-fit tw-min-h-full tw-rounded-full"
+          className="tw-h-full tw-rounded-full"
         />
       ) : (
         <VolleyballIcon />

--- a/src/wwwfiles/components/Toast/Toast.tsx
+++ b/src/wwwfiles/components/Toast/Toast.tsx
@@ -5,7 +5,7 @@ type ToastProps = {
 export const Toast = ({text}: ToastProps) => {
   return (
     <div className='tw-h-full tw-flex tw-flex-col tw-items-center tw-justify-center tw-space-y-5 tw-min-h-[300px] '>
-      <div className='tw-flex tw-items-center tw-w-full tw-max-w-xs tw-p-4 tw-space-x-4 tw-bg-col-gray tw-rounded-lg tw-shadow'>
+      <div className='tw-flex tw-items-center tw-max-w-xs tw-p-4 tw-m-2 tw-space-x-4 tw-bg-col-gray tw-rounded-lg tw-shadow'>
         <div className='tw-pl-4 !tw-text-white tw-text-center'>{text}</div>
       </div>
     </div>


### PR DESCRIPTION
- remove width properties from logos for more reliable presentation across browsers
- remove width and apply margin to error toast for mobile screens